### PR TITLE
更正文件名大小写

### DIFF
--- a/SSokit.pro
+++ b/SSokit.pro
@@ -77,7 +77,7 @@ macx{
 RC_FILE += Icon.icns
 }
 win32{
-RC_ICONS += SSOkit.ico
+RC_ICONS += SSokit.ico
 }
 
 TRANSLATIONS += assets/language/SSokit_zh_CN.ts \


### PR DESCRIPTION
顶层Qt工程中的ico文件名大小写错误